### PR TITLE
fixed error when glob is returning false because of empty result

### DIFF
--- a/app/engine/Package/Utilities.php
+++ b/app/engine/Package/Utilities.php
@@ -141,6 +141,12 @@ class Utilities
     {
         $paths = glob($defaultPath . '*', GLOB_MARK | GLOB_ONLYDIR | GLOB_NOSORT);
         $files = glob($defaultPath . $pattern, $flags);
+        if ($paths === false) {
+            if ($files === false) {
+                return array();
+            }
+            return $files; // error or empty match for sub directories.
+        }
         foreach ($paths as $path) {
             $files = array_merge($files, self::fsRecursiveGlob($path, $pattern, $flags));
         }


### PR DESCRIPTION
From the php manual: http://www.php.net/manual/en/function.glob.php

<pre>
Returns an array containing the matched files/directories, an empty array if no file
matched or FALSE on error.

Note:
On some systems it is impossible to distinguish between empty match and an error.
</pre>
