### PR TITLE
Fix: EngineException - View not found

### DIFF
--- a/app/modules/Core/Helper/Profiler.php
+++ b/app/modules/Core/Helper/Profiler.php
@@ -171,7 +171,12 @@ class Profiler extends Helper
     private function _viewRender($template, $params)
     {
         ob_start();
+
+        $viewsDir = $this->_view->getViewsDir();
+        $this->_view->setViewsDir(ROOT_PATH . '/app/modules/Core/View/');
         $this->_view->partial('partials/profiler/' . $template, $params);
+        $this->_view->setViewsDir($viewsDir);
+
         $html = ob_get_contents();
         ob_end_clean();
 


### PR DESCRIPTION
http://woodzu.vipserv.org/exceptions/EngineException_-_View_not_found.html

Core\Helper\Profile::_viewRender() assumes that each module has partials for rendering profiler.
Instead, its partials should be loaded from the Core module.

Steps to repro:
- go to Packages > Create new package
- give it name "test" and save
- make sure Debug mode is on and you're logged in on front-end
- go to http://phalconeye/tests
