### PR TITLE
[0.4.1] Volt "is not" fix [ci skip]

### DIFF
--- a/app/modules/Core/View/partials/form/default/element.volt
+++ b/app/modules/Core/View/partials/form/default/element.volt
@@ -40,7 +40,7 @@
             </div>
         {% endif %}
         <div class="form_element">
-            {% if instanceof(element, 'Engine\Form\Element\File') and element.getOption('isImage') and element.getValue() is not '/' %}
+            {% if instanceof(element, 'Engine\Form\Element\File') and element.getOption('isImage') and element.getValue() != '/' %}
                 <div class="form_element_file_image">
                     <img alt="" src="{{ element.getValue() }}"/>
                 </div>


### PR DESCRIPTION
`element.getValue() is not "/"` evaluates to: `"value" == !"/"`

where

`element.getValue() != "/"` evaluates to: `"value" != "/"`

See: https://github.com/phalcon/cphalcon/issues/2001
