### PR TITLE
[0.4.1] Models to return compound keys in getId()

### DIFF
--- a/app/engine/Db/AbstractModel.php
+++ b/app/engine/Db/AbstractModel.php
@@ -131,6 +131,10 @@ abstract class AbstractModel extends PhalconModel
      */
     public function getId()
     {
+        if (property_exists($this, 'id')) {
+            return $this->id;
+        }
+
         $primaryKeys = $this->getDI()->get('modelsMetadata')->getPrimaryKeyAttributes($this);
 
         switch (count($primaryKeys)) {


### PR DESCRIPTION
Fix for #54

Example:

``` php
$contentID = \Core\Model\Content::findFirst()->getId(); // 1
$accessID = \Core\Model\Access::findFirst()->getId(); // ['object' => 'AdminArea', 'action' => 'access', 'role_id' => 1]
```
