### PR TITLE
Added nginx rewrite support to router.

### DIFF
--- a/app/engine/ApplicationInitialization.php
+++ b/app/engine/ApplicationInitialization.php
@@ -244,14 +244,14 @@ trait ApplicationInitialization
         // Check installation.
         if (!$config->installed) {
             $router = new RouterAnnotations(false);
-            
+
             // Use $_SERVER['REQUEST_URI'] (NGINX)
             if (!isset($_GET['_url'])) {
                 $router->setUriSource(Router::URI_SOURCE_SERVER_REQUEST_URI);
                 // Remove extra slashes from url
                 $router->removeExtraSlashes(true);
             }
-            
+
             $router->setDefaultModule(Application::SYSTEM_DEFAULT_MODULE);
             $router->setDefaultNamespace($defaultModuleName . '\Controller');
             $router->setDefaultController("Install");
@@ -274,7 +274,7 @@ trait ApplicationInitialization
 
             // Use the annotations router.
             $router = new RouterAnnotations(true);
-            
+
             // Use $_SERVER['REQUEST_URI'] (NGINX)
             if (!isset($_GET['_url'])) {
                 $router->setUriSource(Router::URI_SOURCE_SERVER_REQUEST_URI);


### PR DESCRIPTION
The PhalconEye CMS not working with Nginx rewrite (by default with php-fpm). I fixed this.
Example of my nginx config:

```
server {
  listen            80;
  server_name       phalconeye.dev;
  proxy_set_header  Host phalconeye.dev;

  root              /var/www/htdocs/phalconeye.dev/public; # Site public folder

  access_log      /var/www/htdocs/phalconeye.dev/logs/nginx.access.log;
  error_log         /var/www/htdocs/phalconeye.dev/logs/nginx.error.log;

  location / {
    root  /var/www/htdocs/phalconeye.dev/public;
    try_files  $uri  $uri/  /index.php?$args ;
    index  index.html index.htm index.php;
  }

  location ~ \.php$ {
    root  /var/www/htdocs/phalconeye.dev/public;
    try_files  $uri  $uri/  /index.php?$args ;
    index  index.html index.htm index.php;
    fastcgi_index index.php;
    fastcgi_param PATH_INFO $fastcgi_path_info;
    fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
    fastcgi_param APP_ENV dev;

    fastcgi_pass unix:/var/run/php5-fpm.sock;
    fastcgi_split_path_info ^(.+\.php)(/.+)$;
    include fastcgi_params;
  }

  sendfile off;
}
```
