### PR TITLE
Annotations\Metadata added BC compability with other ORMs

### DIFF
--- a/app/engine/Db/Model/Annotations/Metadata.php
+++ b/app/engine/Db/Model/Annotations/Metadata.php
@@ -328,7 +328,9 @@ class Metadata implements StrategyInterface
      */
     protected function _getColumnName($name, $arguments)
     {
-        if (isset($arguments['column'])) {
+        if (isset($arguments['name'])) {
+            return $arguments['name'];
+        } else if (isset($arguments['column'])) {
             return $arguments['column'];
         } else {
             return $name;


### PR DESCRIPTION
Я уже это делал но во фреймоврке
https://github.com/PhalconEye/framework/commit/4b9f616e2491415a19ad7d1228d24e75622d2ac4

Просто так адекватнее
http://doctrine-orm.readthedocs.org/en/latest/reference/annotations-reference.html#annref-column

Пример

``` php
/**
 * @Column(type="integer", name="login_count" nullable=false, options={"unsigned":true, "default":0})
 */
```

По логике
Анатация называется `Column` и у нее есть свойство `name` согласись так логичнее?

После этого я сделаю ребейз и пришлю пулл реквес что бы мы использовали в `0.5` phalconeye/framework через Composer

Thank you :smile_cat:
