### PR TITLE
[0.5.0] Get PhalconEye working with Phalcon 2.0

### DIFF
--- a/app/engine/Application.php
+++ b/app/engine/Application.php
@@ -46,7 +46,7 @@ class Application extends PhalconApplication
     /**
      * Application configuration.
      *
-     * @var Config
+     * @var \Phalcon\Config
      */
     protected $_config;
 
@@ -264,8 +264,8 @@ class Application extends PhalconApplication
     /**
      * Attach required events.
      *
-     * @param EventsManager $eventsManager Events manager object.
-     * @param Config        $config        Application configuration.
+     * @param EventsManager   $eventsManager Events manager object.
+     * @param \Phalcon\Config $config        Application configuration.
      *
      * @return void
      */

--- a/app/engine/ApplicationInitialization.php
+++ b/app/engine/ApplicationInitialization.php
@@ -65,8 +65,8 @@ trait ApplicationInitialization
     /**
      * Init logger.
      *
-     * @param DIBehaviour|DI $di     Dependency Injection.
-     * @param Config         $config Config object.
+     * @param DIBehaviour|DI  $di     Dependency Injection.
+     * @param \Phalcon\Config $config Config object.
      *
      * @return void
      */
@@ -90,9 +90,9 @@ trait ApplicationInitialization
     /**
      * Init loader.
      *
-     * @param DIBehaviour|DI $di            Dependency Injection.
-     * @param Config         $config        Config object.
-     * @param EventsManager  $eventsManager Event manager.
+     * @param DIBehaviour|DI  $di            Dependency Injection.
+     * @param \Phalcon\Config $config        Config object.
+     * @param EventsManager   $eventsManager Event manager.
      *
      * @return Loader
      */
@@ -131,8 +131,8 @@ trait ApplicationInitialization
     /**
      * Init environment.
      *
-     * @param DIBehaviour|DI $di     Dependency Injection.
-     * @param Config         $config Config object.
+     * @param DIBehaviour|DI  $di     Dependency Injection.
+     * @param \Phalcon\Config $config Config object.
      *
      * @return Url
      */
@@ -182,8 +182,8 @@ trait ApplicationInitialization
     /**
      * Attach required events.
      *
-     * @param EventsManager $eventsManager Events manager object.
-     * @param Config        $config        Application configuration.
+     * @param EventsManager   $eventsManager Events manager object.
+     * @param \Phalcon\Config $config        Application configuration.
      *
      * @return void
      */
@@ -207,8 +207,8 @@ trait ApplicationInitialization
     /**
      * Init annotations.
      *
-     * @param DIBehaviour|DI $di     Dependency Injection.
-     * @param Config         $config Config object.
+     * @param DIBehaviour|DI  $di     Dependency Injection.
+     * @param \Phalcon\Config $config Config object.
      *
      * @return void
      */
@@ -233,8 +233,8 @@ trait ApplicationInitialization
     /**
      * Init router.
      *
-     * @param DIBehaviour|DI $di     Dependency Injection.
-     * @param Config         $config Config object.
+     * @param DIBehaviour|DI  $di     Dependency Injection.
+     * @param \Phalcon\Config $config Config object.
      *
      * @return Router
      */
@@ -317,9 +317,9 @@ trait ApplicationInitialization
     /**
      * Init database.
      *
-     * @param DIBehaviour|DI $di            Dependency Injection.
-     * @param Config         $config        Config object.
-     * @param EventsManager  $eventsManager Event manager.
+     * @param DIBehaviour|DI  $di            Dependency Injection.
+     * @param \Phalcon\Config $config        Config object.
+     * @param EventsManager   $eventsManager Event manager.
      *
      * @return Pdo
      */
@@ -424,8 +424,8 @@ trait ApplicationInitialization
     /**
      * Init session.
      *
-     * @param DIBehaviour|DI $di     Dependency Injection.
-     * @param Config         $config Config object.
+     * @param DIBehaviour|DI  $di     Dependency Injection.
+     * @param \Phalcon\Config $config Config object.
      *
      * @return SessionAdapter
      */
@@ -446,8 +446,8 @@ trait ApplicationInitialization
     /**
      * Init cache.
      *
-     * @param DIBehaviour|DI $di     Dependency Injection.
-     * @param Config         $config Config object.
+     * @param DIBehaviour|DI  $di     Dependency Injection.
+     * @param \Phalcon\Config $config Config object.
      *
      * @return void
      */
@@ -516,9 +516,9 @@ trait ApplicationInitialization
     /**
      * Initialize view.
      *
-     * @param DIBehaviour|DI $di            Dependency Injection.
-     * @param Config         $config        Config object.
-     * @param EventsManager  $eventsManager Event manager.
+     * @param DIBehaviour|DI  $di            Dependency Injection.
+     * @param \Phalcon\Config $config        Config object.
+     * @param EventsManager   $eventsManager Event manager.
      *
      * @return void
      */

--- a/app/engine/Asset/Manager.php
+++ b/app/engine/Asset/Manager.php
@@ -299,7 +299,10 @@ class Manager extends AssetManager
      */
     public function outputInline(Collection $collection, $type)
     {
-        return implode('\n', $this->_inline);
+        $html = parent::outputInline($collection, $type);
+        $html .= implode('\n', $this->_inline);
+
+        return $html;
     }
 
     /**

--- a/app/engine/Asset/Manager.php
+++ b/app/engine/Asset/Manager.php
@@ -293,9 +293,11 @@ class Manager extends AssetManager
     /**
      * Get <head> tag inline code.
      *
+     * @param Collection $collection
+     * @param string     $type
      * @return string
      */
-    public function outputInline()
+    public function outputInline(Collection $collection, $type)
     {
         return implode('\n', $this->_inline);
     }

--- a/app/engine/Asset/Manager.php
+++ b/app/engine/Asset/Manager.php
@@ -291,18 +291,13 @@ class Manager extends AssetManager
     }
 
     /**
-     * Get <head> tag inline code.
+     * Get additional <head> tag inline code.
      *
-     * @param Collection $collection
-     * @param string     $type
      * @return string
      */
-    public function outputInline(Collection $collection, $type)
+    public function outputInlineHead()
     {
-        $html = parent::outputInline($collection, $type);
-        $html .= implode('\n', $this->_inline);
-
-        return $html;
+        return implode('\n', $this->_inline);
     }
 
     /**
@@ -339,6 +334,18 @@ class Manager extends AssetManager
     }
 
     /**
+     * Prints inline js code.
+     *
+     * @param string $collectionName the name of the collection
+     *
+     * @return string
+     **/
+    public function outputInlineJs($collectionName = self::DEFAULT_COLLECTION_JS)
+    {
+        return parent::outputInlineJs($collectionName);
+    }
+
+    /**
      * Prints the HTML for CSS resources.
      *
      * @param string $collectionName the name of the collection
@@ -370,6 +377,18 @@ class Manager extends AssetManager
         }
         return parent::outputCss($collectionName);
 
+    }
+
+    /**
+     * Prints inline css code.
+     *
+     * @param string $collectionName the name of the collection
+     *
+     * @return string
+     **/
+    public function outputInlineCss($collectionName = self::DEFAULT_COLLECTION_CSS)
+    {
+        return parent::outputInlineCss($collectionName);
     }
 
     /**

--- a/app/engine/Config.php
+++ b/app/engine/Config.php
@@ -79,10 +79,10 @@ class Config extends PhalconConfig
     /**
      * Create configuration object.
      *
-     * @param array|null  $arrayConfig Configuration data.
+     * @param array       $arrayConfig Configuration data.
      * @param string|null $stage       Configuration stage.
      */
-    public function __construct($arrayConfig = null, $stage = null)
+    public function __construct($arrayConfig = [], $stage = null)
     {
         $this->_currentStage = $stage;
         parent::__construct($arrayConfig);
@@ -162,7 +162,7 @@ class Config extends PhalconConfig
      */
     protected static function _getConfiguration($stage)
     {
-        $config = new Config(null, $stage);
+        $config = new Config([], $stage);
         $configDirectory = ROOT_PATH . self::CONFIG_PATH . $stage;
         $configFiles = glob($configDirectory .'/*.php');
 

--- a/app/engine/Config.php
+++ b/app/engine/Config.php
@@ -90,7 +90,7 @@ class Config
                 $config->stage = $stage;
             } else {
                 $config = self::_getConfiguration($stage);
-                $config->refreshCache();
+                self::refreshCache($config);
             }
         }
 
@@ -150,12 +150,13 @@ class Config
      * @param string|array  $sections Config section name to save. By default: Config::CONFIG_DEFAULT_SECTION.
      *
      * @return void
+     * @throws Exception if invalid configuration is used
      */
     public static function save(PhalconConfig $config, $sections = self::CONFIG_DEFAULT_SECTION)
     {
         // Added here to protect the config file from overriding by custom instance
         if (!$config->stage) {
-            return;
+            throw new Exception('Using invalid configuration');
         }
 
         $configDirectory = ROOT_PATH . self::CONFIG_PATH . $config->stage;
@@ -170,8 +171,27 @@ class Config
             );
         }
 
-        // Refresh cache
-        file_put_contents(ROOT_PATH . self::CONFIG_CACHE_PATH, self::_toConfigurationString($config->toArray()));
+        self::refreshCache($config);
+    }
+
+    /**
+     * Save config file into cached config file.
+     *
+     * @param PhalconConfig $config Config instance
+     *
+     * @return void
+     * @throws Exception if invalid configuration is used
+     */
+    public static function refreshCache(PhalconConfig $config)
+    {
+        // Added here to protect the config file from overriding by custom instance
+        if (!$config->stage) {
+            throw new Exception('Using invalid configuration');
+        }
+
+        $data = $config->toArray();
+
+        file_put_contents(ROOT_PATH . self::CONFIG_CACHE_PATH, self::_toConfigurationString($data));
     }
 
     /**
@@ -179,7 +199,7 @@ class Config
      *
      * @param array $data Configuration data.
      *
-     * @return void
+     * @return string
      */
     protected static function _toConfigurationString(array $data)
     {

--- a/app/engine/Config.php
+++ b/app/engine/Config.php
@@ -177,16 +177,16 @@ class Config extends PhalconConfig
 
         foreach ($configFiles as $file) {
             $data = include_once($file);
-            $config->offsetSet(basename($file, ".php"), $data);
+            $config->offsetSet(basename($file, ".php"), new PhalconConfig($data));
         }
 
         $appPath = ROOT_PATH . self::CONFIG_METADATA_APP;
 
         if (!file_exists($appPath)) {
             $config->offsetSet('installed', false);
-            $config->offsetSet('events', array());
-            $config->offsetSet('modules', array());
-            $config->offsetSet('widgets', array());
+            $config->offsetSet('events', new PhalconConfig);
+            $config->offsetSet('modules', new PhalconConfig);
+            $config->offsetSet('widgets', new PhalconConfig);
             return $config;
         }
 

--- a/app/engine/Form/Validation.php
+++ b/app/engine/Form/Validation.php
@@ -20,9 +20,9 @@ namespace Engine\Form;
 
 use Engine\Db\AbstractModel;
 use Engine\Form\Behaviour\ContainerBehaviour;
-use Engine\Form\Behaviour\FieldSetBehaviour;
 use Engine\Form;
 use Phalcon\Validation as PhalconValidation;
+use Phalcon\Validation\ValidatorInterface;
 
 
 /**
@@ -66,31 +66,31 @@ class Validation extends PhalconValidation
     /**
      * Add validator to validation.
      *
-     * @param string                      $attribute Attribute name.
-     * @param PhalconValidation\Validator $validator Validator object.
+     * @param string             $field     Attribute name.
+     * @param ValidatorInterface $validator Validator object.
      *
      * @throws Exception
      * @return $this
      */
-    public function add($attribute, $validator)
+    public function add($field, ValidatorInterface $validator)
     {
-        if (!$this->_container->has($attribute)) {
-            throw new Exception(sprintf('Element "%s" not found in current elements container.', $attribute));
+        if (!$this->_container->has($field)) {
+            throw new Exception(sprintf('Element "%s" not found in current elements container.', $field));
         }
-        $this->_preparedValidators[$attribute][] = $validator;
+        $this->_preparedValidators[$field][] = $validator;
         return $this;
     }
 
     /**
      * Remove validator from validation.
      *
-     * @param string $attribute Attribute name.
+     * @param string $field Attribute name.
      *
      * @return $this
      */
-    public function remove($attribute)
+    public function remove($field)
     {
-        unset($this->_preparedValidators[$attribute]);
+        unset($this->_preparedValidators[$field]);
         return $this;
     }
 
@@ -108,9 +108,9 @@ class Validation extends PhalconValidation
             return new PhalconValidation\Message\Group();
         }
 
-        foreach ($this->_preparedValidators as $attribute => $validators) {
+        foreach ($this->_preparedValidators as $field => $validators) {
             foreach ($validators as $validator) {
-                parent::add($attribute, $validator);
+                parent::add($field, $validator);
             }
         }
 

--- a/app/engine/Installer.php
+++ b/app/engine/Installer.php
@@ -71,7 +71,7 @@ abstract class Installer
         if (file_exists($filePath)) {
             $connection = $this->getDI()->get('db');
             $connection->begin();
-            $connection->query(file_get_contents($filePath));
+            $connection->execute(file_get_contents($filePath));
             $connection->commit();
         } else {
             throw new Exception(sprintf('Sql file "%s" does not exists', $filePath));

--- a/app/engine/Package/Manager.php
+++ b/app/engine/Package/Manager.php
@@ -23,6 +23,7 @@ use Engine\Behaviour\DIBehaviour;
 use Engine\Config;
 use Engine\Package\Exception\InvalidManifest;
 use Engine\Package\Model\AbstractPackage;
+use Phalcon\Config as PhalconConfig;
 use Phalcon\DI;
 use Phalcon\Filter as PhalconFilter;
 
@@ -254,7 +255,7 @@ class Manager
      * @param string $packageFilePath Zip archive filepath.
      *
      * @throws PackageException
-     * @return Config
+     * @return PhalconConfig
      */
     public function installPackage($packageFilePath)
     {
@@ -415,7 +416,7 @@ class Manager
     /**
      * Run package installation script.
      *
-     * @param Config $manifest Module config.
+     * @param PhalconConfig $manifest Module config.
      *
      * @return string
      */
@@ -591,7 +592,7 @@ class Manager
      * @param string $manifestLocation Manifest path.
      *
      * @throws InvalidManifest
-     * @return Config
+     * @return PhalconConfig
      */
     private function _readPackageManifest($manifestLocation)
     {
@@ -609,7 +610,7 @@ class Manager
             throw new InvalidManifest('Manifest file is invalid or damaged.');
         }
 
-        return new Config($manifest);
+        return new PhalconConfig($manifest);
     }
 
     /**
@@ -682,7 +683,7 @@ class Manager
     /**
      * Check package dependencies.
      *
-     * @param Config $manifest Package manifest.
+     * @param PhalconConfig $manifest Package manifest.
      *
      * @throws PackageException
      * @return void

--- a/app/engine/Plugin/CacheAnnotation.php
+++ b/app/engine/Plugin/CacheAnnotation.php
@@ -63,8 +63,8 @@ class CacheAnnotation extends PhalconPlugin
             $options = ['lifetime' => $lifetime];
 
             // Check if there is a user defined cache key.
-            if ($annotation->hasNamedArgument('key')) {
-                $options['key'] = $annotation->getNamedArgument('key');
+            if ($annotation->hasArgument('key')) {
+                $options['key'] = $annotation->hasArgument('key');
             }
 
             // Enable the cache for the current method.

--- a/app/engine/Plugin/CacheAnnotation.php
+++ b/app/engine/Plugin/CacheAnnotation.php
@@ -46,7 +46,7 @@ class CacheAnnotation extends PhalconPlugin
     {
         // Parse the annotations in the method currently executed.
         $annotations = $this->annotations->getMethod(
-            $dispatcher->getActiveController(),
+            get_class($dispatcher->getActiveController()),
             $dispatcher->getActiveMethod()
         );
 

--- a/app/engine/Translation/Db.php
+++ b/app/engine/Translation/Db.php
@@ -37,7 +37,7 @@ use Phalcon\Translate\Exception;
  * @license   New BSD License
  * @link      http://phalconeye.com/
  */
-class Db implements AdapterInterface
+class Db extends Adapter implements AdapterInterface
 {
     use DIBehaviour {
         DIBehaviour::__construct as protected __DIConstruct;
@@ -71,19 +71,6 @@ class Db implements AdapterInterface
         $this->__DIConstruct($di);
         $this->_languageId = $languageId;
         $this->_translationModel = $model;
-    }
-
-    /**
-     * Returns the translation string of the given key.
-     *
-     * @param string $translateKey Key.
-     * @param array  $placeholders Placeholders.
-     *
-     * @return string
-     */
-    public function _($translateKey, $placeholders = null)
-    {
-        return $this->query($translateKey, $placeholders);
     }
 
     /**

--- a/app/engine/View.php
+++ b/app/engine/View.php
@@ -51,10 +51,10 @@ class View extends PhalconView
      * Create view instance.
      * If no events manager provided - events would not be attached.
      *
-     * @param DIBehaviour  $di             DI.
-     * @param Config       $config         Configuration.
-     * @param string|null  $viewsDirectory Views directory location.
-     * @param Manager|null $em             Events manager.
+     * @param DIBehaviour     $di             DI.
+     * @param \Phalcon\Config $config         Configuration.
+     * @param string|null     $viewsDirectory Views directory location.
+     * @param Manager|null    $em             Events manager.
      *
      * @return View
      */

--- a/app/modules/Core/Api/Acl.php
+++ b/app/modules/Core/Api/Acl.php
@@ -209,10 +209,10 @@ class Acl extends AbstractApi
         if ($annotations && $annotations->has('Acl')) {
             $annotation = $annotations->get('Acl');
 
-            if ($annotation->hasNamedArgument('actions')) {
+            if ($annotation->hasArgument('actions')) {
                 $object->actions = $annotation->getNamedArgument('actions');
             }
-            if ($annotation->hasNamedArgument('options')) {
+            if ($annotation->hasArgument('options')) {
                 $object->options = $annotation->getNamedArgument('options');
             }
         } else {

--- a/app/modules/Core/Bootstrap.php
+++ b/app/modules/Core/Bootstrap.php
@@ -28,6 +28,7 @@ use Engine\Config;
 use Engine\Translation\Db as TranslationDb;
 use Phalcon\DI;
 use Phalcon\DiInterface;
+use Phalcon\Config as PhalconConfig;
 use Phalcon\Events\Manager;
 use Phalcon\Mvc\View\Engine\Volt;
 use Phalcon\Mvc\View;
@@ -106,12 +107,12 @@ class Bootstrap extends EngineBootstrap
     /**
      * Init locale.
      *
-     * @param DI     $di     Dependency injection.
-     * @param Config $config Dependency injection.
+     * @param DI            $di     Dependency injection.
+     * @param PhalconConfig $config Config
      *
      * @return void
      */
-    protected function _initI18n(DI $di, Config $config)
+    protected function _initI18n(DI $di, PhalconConfig $config)
     {
         if ($di->get('app')->isConsole()) {
             return;

--- a/app/modules/Core/Controller/AbstractController.php
+++ b/app/modules/Core/Controller/AbstractController.php
@@ -46,7 +46,7 @@ use Phalcon\Mvc\View;
  * @property \Engine\Application        $app
  * @property \Engine\View               $view
  * @property \Engine\Asset\Manager      $assets
- * @property \Engine\Config             $config
+ * @property \Phalcon\Config            $config
  * @property \Phalcon\Translate\Adapter $i18n
  * @property DIBehaviour|DI             $di
  *

--- a/app/modules/Core/Controller/AdminIndexController.php
+++ b/app/modules/Core/Controller/AdminIndexController.php
@@ -18,6 +18,8 @@
 
 namespace Core\Controller;
 
+use Engine\Config;
+
 /**
  * Admin Index controller.
  *
@@ -54,7 +56,7 @@ class AdminIndexController extends AbstractAdminController
     {
         $this->view->disable();
         $this->config->application->debug = (bool)$this->request->get('debug', null, true);
-        $this->config->save();
+        Config::save($this->config);
         $this->_clearCache();
     }
 

--- a/app/modules/Core/Controller/AdminPerformanceController.php
+++ b/app/modules/Core/Controller/AdminPerformanceController.php
@@ -20,7 +20,8 @@ namespace Core\Controller;
 
 use Core\Form\Admin\Setting\Performance as PerformanceForm;
 use Core\Model\Settings;
-use Phalcon\Config;
+use Engine\Config;
+use Phalcon\Config as PhalconConfig;
 
 /**
  * Admin performance settings.
@@ -102,8 +103,8 @@ class AdminPerformanceController extends AbstractAdminController
                 break;
         }
 
-        $this->config->application->cache = new Config($cacheData);
-        $this->config->save();
+        $this->config->application->cache = new PhalconConfig($cacheData);
+        Config::save($this->config);
         $this->flash->success('Settings saved!');
     }
 }

--- a/app/modules/Core/Controller/InstallController.php
+++ b/app/modules/Core/Controller/InstallController.php
@@ -28,6 +28,7 @@ use Engine\Db\Model\Annotations\Initializer as ModelAnnotationsInitializer;
 use Engine\Db\Schema;
 use Engine\Package\Manager as PackageManager;
 use Phalcon\Assets\Collection as AssetsCollection;
+use Phalcon\Config as PhalconConfig;
 use Phalcon\Events\Manager as EventsManager;
 use Phalcon\Http\ResponseInterface;
 use Phalcon\Mvc\Model\Manager as ModelManager;
@@ -246,7 +247,7 @@ class InstallController extends AbstractController
                 $packageManager = new PackageManager([], $this->di);
                 foreach ($this->di->get('registry')->modules as $moduleName) {
                     $packageManager->runInstallScript(
-                        new Config(
+                        new PhalconConfig(
                             [
                                 'name' => $moduleName,
                                 'type' => PackageManager::PACKAGE_TYPE_MODULE,
@@ -257,7 +258,8 @@ class InstallController extends AbstractController
                     );
                 }
 
-                $this->config->save('database');
+                Config::save($this->config, 'database');
+
                 $this->_setPassed(__FUNCTION__, true);
             } catch (\Exception $ex) {
                 $form->addError($ex->getMessage());
@@ -395,7 +397,7 @@ class InstallController extends AbstractController
     protected function _setupDatabase($connectionSettings = null)
     {
         if ($connectionSettings != null) {
-            $this->config->database = new Config($connectionSettings);
+            $this->config->database = new PhalconConfig($connectionSettings);
         }
 
         $config = $this->config;

--- a/app/modules/Core/Helper/Profiler.php
+++ b/app/modules/Core/Helper/Profiler.php
@@ -18,7 +18,6 @@
 
 namespace Core\Helper;
 
-use Engine\Config;
 use Engine\Helper;
 use Engine\Profiler as EngineProfiler;
 use Phalcon\DI;
@@ -48,7 +47,7 @@ class Profiler extends Helper
     /**
      * Config object.
      *
-     * @var Config
+     * @var \Phalcon\Config
      */
     protected $_config;
 

--- a/app/modules/Core/View/layouts/admin.volt
+++ b/app/modules/Core/View/layouts/admin.volt
@@ -23,9 +23,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
 
-    {{ assets.outputCss() }}
+    {{ assets.outputInlineHead() }}
 
-    {{ assets.outputInline() }}
+    {{ assets.outputCss() }}
+    {{ assets.outputInlineCss() }}
 
     <script type="text/javascript">
         {{ helper('i18n', 'core').render() }}
@@ -81,6 +82,6 @@
 </div>
 
 {{ assets.outputJs() }}
-
+{{ assets.outputInlineJs() }}
 </body>
 </html>

--- a/app/modules/Core/View/layouts/main.volt
+++ b/app/modules/Core/View/layouts/main.volt
@@ -25,9 +25,10 @@
     <meta name="generator" content="PhalconEye - Open Source Content Management System">
     <link href="favicon.ico" rel="shortcut icon" type="image/x-icon"/>
 
-    {{ assets.outputCss() }}
+    {{ assets.outputInlineHead() }}
 
-    {{ assets.outputInline() }}
+    {{ assets.outputCss() }}
+    {{ assets.outputInlineCss() }}
 
     <script type="text/javascript">
         {{ helper('i18n', 'core').render() }}
@@ -70,6 +71,7 @@
 </div>
 
 {{ assets.outputJs() }}
+{{ assets.outputInlineJs() }}
 {{ helper('profiler', 'core').render() }}
 </body>
 </html>


### PR DESCRIPTION
This PR addresses a couple of first line issues with running the CMS with Phalcon 2.0.
It is purely for discussion as I didn't do any kind of detailed tests - just went thorugh installation fixing whatever I found and logged into admin. That's it.

There seem to be many B/C issues (usually minor) in Phalcon 2.0 which I hope will be detailed in some kind of migration process at some point.
There's even one PR for this https://github.com/phalcon/cphalcon/issues/3024
Ofcourse this PR breaks compatibility with 1.3.x due to the changes in public api.

Using most recent version https://github.com/phalcon/cphalcon/commit/4b1cf968e7697a9eed82e4cc38837d2cb03a18ff