### PR TITLE
Added flags on css/js files to define as local to work around 1.3.4 phalcon issues

### DIFF
--- a/app/modules/Core/Controller/AbstractAdminController.php
+++ b/app/modules/Core/Controller/AbstractAdminController.php
@@ -181,17 +181,17 @@ abstract class AbstractAdminController extends AbstractController
         $this->assets->set(
             AssetManager::DEFAULT_COLLECTION_CSS,
             $this->assets->getEmptyCssCollection()
-                ->addCss('external/bootstrap/css/bootstrap.min.css')
-                ->addCss('external/bootstrap/css/bootstrap-switch.min.css')
-                ->addCss('external/jquery/jquery-ui.css')
-                ->addCss('assets/css/core/admin/main.css')
+                ->addCss('external/bootstrap/css/bootstrap.min.css',false)
+                ->addCss('external/bootstrap/css/bootstrap-switch.min.css',false)
+                ->addCss('external/jquery/jquery-ui.css',false)
+                ->addCss('assets/css/core/admin/main.css',false)
                 ->join(false)
         );
 
         $this->assets->get(AssetManager::DEFAULT_COLLECTION_JS)
-            ->addJs('external/bootstrap/js/bootstrap.min.js')
-            ->addJs('external/bootstrap/js/bootstrap-switch.min.js')
-            ->addJs('external/ckeditor/ckeditor.js');
+            ->addJs('external/bootstrap/js/bootstrap.min.js',false)
+            ->addJs('external/bootstrap/js/bootstrap-switch.min.js',false)
+            ->addJs('external/ckeditor/ckeditor.js',false);
     }
 
     /**

--- a/app/modules/Core/Controller/AbstractController.php
+++ b/app/modules/Core/Controller/AbstractController.php
@@ -207,35 +207,35 @@ abstract class AbstractController extends PhalconController
         $this->assets->set(
             AssetManager::DEFAULT_COLLECTION_CSS,
             $this->assets->getEmptyCssCollection()
-                ->addCss('external/jquery/jquery-ui.css')
-                ->addCss('assets/css/constants.css')
-                ->addCss('assets/css/theme.css')
+                ->addCss('external/jquery/jquery-ui.css',false)
+                ->addCss('assets/css/constants.css',false)
+                ->addCss('assets/css/theme.css',false)
         );
 
         $this->assets->set(
             AssetManager::DEFAULT_COLLECTION_JS,
             $this->assets->getEmptyJsCollection()
-                ->addJs('external/jquery/jquery-2.1.0.js')
-                ->addJs('external/jquery/jquery-ui-1.10.4.js')
-                ->addJs('external/jquery/jquery.cookie.js')
-                ->addJs('assets/js/core/core.js')
-                ->addJs('assets/js/core/i18n.js')
-                ->addJs('assets/js/core/form.js')
-                ->addJs('assets/js/core/form/remote-file.js')
-                ->addJs('assets/js/core/widgets/grid.js')
-                ->addJs('assets/js/core/widgets/autocomplete.js')
-                ->addJs('assets/js/core/widgets/modal.js')
-                ->addJs('assets/js/core/widgets/ckeditor.js')
+                ->addJs('external/jquery/jquery-2.1.0.js',false)
+                ->addJs('external/jquery/jquery-ui-1.10.4.js',false)
+                ->addJs('external/jquery/jquery.cookie.js',false)
+                ->addJs('assets/js/core/core.js',false)
+                ->addJs('assets/js/core/i18n.js',false)
+                ->addJs('assets/js/core/form.js',false)
+                ->addJs('assets/js/core/form/remote-file.js',false)
+                ->addJs('assets/js/core/widgets/grid.js',false)
+                ->addJs('assets/js/core/widgets/autocomplete.js',false)
+                ->addJs('assets/js/core/widgets/modal.js',false)
+                ->addJs('assets/js/core/widgets/ckeditor.js',false)
         );
 
         if ($this->di->has('profiler')) {
             $this->di->get('assets')
                 ->collection(AssetManager::DEFAULT_COLLECTION_CSS)
-                ->addCss('assets/css/core/profiler.css');
+                ->addCss('assets/css/core/profiler.css',false);
 
             $this->di->get('assets')
                 ->collection(AssetManager::DEFAULT_COLLECTION_JS)
-                ->addCss('assets/js/core/profiler.js');
+                ->addCss('assets/js/core/profiler.js',false);
         }
 
         $this->addDefaultJsTranslations();

--- a/app/modules/Core/View/AdminIndex/index.volt
+++ b/app/modules/Core/View/AdminIndex/index.volt
@@ -20,7 +20,7 @@
 {% block title %}Admin panel{% endblock %}
 
 {% block head %}
-    {{ helper('assets').addJs('assets/js/core/admin/dashboard.js') }}
+    {{ javascript_include("assets/js/core/admin/dashboard.js") }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This allows PhalconEye to render assets and work around the Phalcon 1.3.4 "have the same source and target paths" exception error when viewing the site or admin.